### PR TITLE
Fixed docker + codegen issue with go version mismatches

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -8,6 +8,7 @@ github.com/IBM/sarama v1.43.1/go.mod h1:GG5q1RURtDNPz8xxJs3mgX6Ytak8Z9eLhAkJPObe
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGWcpt8ov532z81sp/kMMUG485J2InIOyADM=
 github.com/blueprint-uservices/blueprint/examples/dsb_hotel/workflow v0.0.0-20240120085724-a66c24cd32b1 h1:F0WX+DiurLGjUWmvJ/VAP0bgYul7MlMRh94q3zXXtGA=
 github.com/blueprint-uservices/blueprint/examples/dsb_hotel/workflow v0.0.0-20240120085724-a66c24cd32b1/go.mod h1:VlZJnce12IRJ29n9lGWrRBBAtz56y5NTc/ZYdWrtC3k=
+github.com/blueprint-uservices/blueprint/examples/train_ticket/tests v0.0.0-20240619221802-d064c5861c1e/go.mod h1:wS3qxcA4dWpBuEMftfkwwTdPGeNIlx8/GAGqgoTYwyA=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -113,6 +114,7 @@ golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.18.0/go.mod h1:/czyP5RqHAH4odGYxBJ1qz0+CE5WZ+2j1YgoEo8F2jQ=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
+golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
 golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
 golang.org/x/oauth2 v0.17.0/go.mod h1:OzPDGQiuQMguemayvdylqddI7qcD9lnSDb+1FiwQ5HA=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/plugins/golang/gogen/workspacebuilder.go
+++ b/plugins/golang/gogen/workspacebuilder.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"runtime"
+	"strings"
 
 	"path/filepath"
 
@@ -27,12 +27,6 @@ type WorkspaceBuilderImpl struct {
 	ModuleDirs       map[string]string // map from FQ module name to directory name within WorkspaceDir
 	Modules          map[string]string // map from directory name to FQ module name within WorkspaceDir
 	GeneratedModules map[string]string // map from directory name to FQ module name within WorkspaceDir
-}
-
-// getGoVersionNumber returns the Go version number without the "go" prefix
-func getGoVersionNumber() string {
-	version := runtime.Version()
-	return version[2:]
 }
 
 // Creates a golang workspace in the specified directory on the local filesystem.
@@ -98,7 +92,11 @@ func (workspace *WorkspaceBuilderImpl) CreateModule(moduleName string, moduleVer
 	workspace.GeneratedModules[moduleShortName] = moduleName
 
 	// Create the go.mod file
-	goVersion := getGoVersionNumber()
+	// modfileContents := fmt.Sprintf("module %v\n\ngo 1.22", moduleName)
+	goVersion := strings.TrimPrefix(runtime.Version(), "go")
+	if strings.Count(goVersion, ".") > 1 {
+		goVersion = goVersion[:strings.LastIndex(goVersion, ".")]
+	}
 	modfileContents := fmt.Sprintf("module %v\n\ngo %s", moduleName, goVersion)
 	modfile := filepath.Join(moduleDir, "go.mod")
 
@@ -175,13 +173,13 @@ func (workspace *WorkspaceBuilderImpl) readModfile(moduleSubDir string) (*modfil
 	return f, nil
 }
 
-var goWorkTemplate = `go {{ .GoVersion }}
+var goWorkTemplate = fmt.Sprintf(`go %s
 
 use (
 	{{ range $dirName, $moduleName := .Modules }}./{{ $dirName }}
 	{{ end }}
 )
-`
+`, strings.TrimPrefix(runtime.Version(), "go"))
 
 // This method should be called by plugins after all modules in a workspace have been combined.
 //
@@ -190,17 +188,8 @@ use (
 //   - updates the go.mod files of all contained modules with 'replace' directives for any required modules that exist in the workspace
 func (workspace *WorkspaceBuilderImpl) Finish() error {
 	// Generate the go.work file
-	goVersion := getGoVersionNumber()
-	templateData := struct {
-		Modules   map[string]string
-		GoVersion string
-	}{
-		Modules:   workspace.Modules,
-		GoVersion: goVersion,
-	}
-	
 	workFileName := filepath.Join(workspace.WorkspaceDir, "go.work")
-	err := ExecuteTemplateToFile("go.work", goWorkTemplate, templateData, workFileName)
+	err := ExecuteTemplateToFile("go.work", goWorkTemplate, workspace, workFileName)
 	if err != nil {
 		return err
 	}

--- a/plugins/goproc/linuxgen/dockerfile_buildcommands.go
+++ b/plugins/goproc/linuxgen/dockerfile_buildcommands.go
@@ -1,8 +1,10 @@
 package linuxgen
 
 import (
-	"github.com/blueprint-uservices/blueprint/plugins/golang/gogen"
 	"runtime"
+	"strings"
+
+	"github.com/blueprint-uservices/blueprint/plugins/golang/gogen"
 )
 
 /*
@@ -10,22 +12,16 @@ If the goproc is being deployed to Docker, we can provide some custom
 build commands to add to the Dockerfile
 */
 func GenerateDockerfileBuildCommands(goProcName string) (string, error) {
-	goVersion := getGoVersionNumber()
-	
+	goVersion := strings.TrimPrefix(runtime.Version(), "go")
 	args := dockerfileBuildTemplateArgs{
-		ProcName: goProcName,
+		ProcName:  goProcName,
 		GoVersion: goVersion,
 	}
 	return gogen.ExecuteTemplate("dockerfile_buildgoproc", dockerfileBuildTemplate, args)
 }
 
-func getGoVersionNumber() string {
-	version := runtime.Version()
-	return version[2:]
-}
-
 type dockerfileBuildTemplateArgs struct {
-	ProcName string
+	ProcName  string
 	GoVersion string
 }
 


### PR DESCRIPTION
Updated plugins/golang/gogen/workspacebuilder.go and plugins/goproc/linuxgen/dockerfile_buildcommands.go to dynamically fetch go version and inject it into templates.

Fix #2 